### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -164,10 +164,10 @@ geoip:
 	  cp ~/dat_files/* httpdocs/geoip; gunzip -f httpdocs/geoip/*.dat.gz ; \
 	else \
 	  cd httpdocs/geoip; \
-	  wget -nc http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
-	  wget -nc http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz; \
-	  wget -nc http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz; \
-	  wget -nc http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz; \
+	  wget -nc https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
+	  wget -nc https://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz; \
+	  wget -nc https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz; \
+	  wget -nc https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz; \
 	  gunzip -f *.dat.gz ; \
 	fi
 


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).